### PR TITLE
fix for user id extraction from auth0 info

### DIFF
--- a/server/src/auth/auth0.js
+++ b/server/src/auth/auth0.js
@@ -45,7 +45,7 @@ function auth0(horizon, raw_options) {
     https.request({ host, path: '/userinfo',
                     headers: { Authorization: `Bearer ${access_token}` } });
 
-  const extract_id = (user_info) => user_info && user_info.identities[0].user_id;
+  const extract_id = (user_info) => user_info && user_info.user_id;
 
 
   auth_utils.oauth2({


### PR DESCRIPTION
I was able to get auth0 to work with their user database connector, providing e-mail/password authentication. However, I was unable to get auth0 social connections (i.e. Google) to work, until I made this change to the `extract_id` function in `auth0.js`. The id created by this function was missing the auth0 prefix (i.e. `google-oauth2|`). This makes it impossible to determine the actual auth0 `user_id`, which can be used with their Management API to retrieve additional user info (i.e. name, picture URL, etc.) (I have embedded Horizon server in Express with an endpoint to facilitate this additional functionality for my app.) Unfortunately, this change will force Horizon server to create new records for auth0 users that have previously authenticated. Hopefully this is not a big deal since Horizon 2.0 is still in beta.
